### PR TITLE
Retries with backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A reliable job queue implemented in Erlang.
 - [x] Dead-letter queues (`on_discard`)
 - [x] Queue introspection and manual job pruning
 - [x] Delayed job scheduling
-- [ ] Automatic retries with backoff
+- [x] Automatic retries with backoff
 - [ ] Drain and flush (graceful shutdown)
 - [ ] Job execution timeouts
 - [ ] Worker shutdown timeouts
@@ -107,7 +107,7 @@ Queues are configured via `gaffer:queue_conf()` maps:
 
   Storage driver.
 
-- `max_workers` (`pos_integer()`, default = `5`)
+- `max_workers` (`pos_integer()`, default = `1`)
 
   Max concurrent workers per node.
 

--- a/src/gaffer.erl
+++ b/src/gaffer.erl
@@ -88,7 +88,7 @@ An `erlang:system_time/0` integer or a `{Unit, Value}` pair.
 -type timeout_ms() :: pos_integer().
 -doc #{group => "Job Types"}.
 -doc "Retry backoff strategy.".
--type backoff() :: [non_neg_integer()].
+-type backoff() :: non_neg_integer() | [non_neg_integer()].
 -doc #{group => "Job Types"}.
 -doc "Grace period for worker shutdown in milliseconds.".
 -type shutdown_timeout() :: pos_integer().

--- a/src/gaffer_queue.erl
+++ b/src/gaffer_queue.erl
@@ -248,22 +248,25 @@ complete_job(Queue, Id, Result) ->
     {ok, gaffer:job()} | {error, not_found}.
 fail_job(Queue, Id, Reason) ->
     Conf = conf(Queue),
-    Result = modify_job(Conf, Id, [gaffer, job, fail], fun(Job) ->
-        Attempt = maps:get(attempt, Job) + 1,
-        MaxAttempts = maps:get(max_attempts, Job),
-        Job1 = Job#{attempt := Attempt},
-        Error = #{
-            attempt => Attempt, error => Reason, at => erlang:system_time()
-        },
-        Job2 = add_error(Job1, Error),
-        case Attempt >= MaxAttempts of
-            true -> transition(Job2, discarded);
-            false -> transition(Job2, available)
-        end
-    end),
+    Result =
+        modify_job(Conf, Id, [gaffer, job, fail], fun(
+            #{attempt := Attempt} = Job
+        ) ->
+            case add_error(Job#{attempt := Attempt + 1}, Reason) of
+                #{attempt := A, max_attempts := M} = Job1 when A >= M ->
+                    transition(Job1, discarded);
+                Job1 ->
+                    transition(schedule_backoff(Job1), available)
+            end
+        end),
     {ok, Job} = Result,
     maybe_forward(Conf, Job),
     Result.
+
+schedule_backoff(#{backoff := Backoff, attempt := Attempt} = Job) ->
+    Now = erlang:system_time(millisecond),
+    Time = timestamp({millisecond, Now + backoff(Attempt, Backoff)}),
+    Job#{scheduled_at => Time}.
 
 -spec schedule_job(gaffer:queue(), gaffer:job_id(), gaffer:timestamp()) ->
     {ok, gaffer:job()} | {error, not_found}.
@@ -307,6 +310,11 @@ is_gaffer_key(_) -> false.
 
 timestamp({Unit, V}) -> erlang:convert_time_unit(V, Unit, native);
 timestamp(Native) when is_integer(Native) -> Native.
+
+backoff(_Attempt, Backoff) when is_integer(Backoff) -> Backoff;
+backoff(_Attempt, [Backoff]) -> Backoff;
+backoff(1, [Backoff | _]) -> Backoff;
+backoff(Attempt, [_ | Tail]) -> backoff(Attempt - 1, Tail).
 
 % Config validation
 
@@ -406,7 +414,8 @@ transition(#{state := From} = Job, To) ->
             {error, {invalid_transition, {From, To}}}
     end.
 
-add_error(#{errors := Errors} = Job, Error) ->
+add_error(#{errors := Errors, attempt := Attempt} = Job, Reason) ->
+    Error = #{attempt => Attempt, error => Reason, at => erlang:system_time()},
     Job#{errors := [normalize_error(Error) | Errors]}.
 
 normalize_error(#{error := Err} = Error) ->

--- a/test/gaffer_tests.erl
+++ b/test/gaffer_tests.erl
@@ -69,6 +69,9 @@ gaffer_test_() ->
         fun fail_retryable/1,
         fun fail_discarded/1,
         fun fail_error_normalization/1,
+        % Retries
+        fun retries_backoff/1,
+        fun retries_only_one_value/1,
         % Schedule
         fun schedule/1,
         % Claim
@@ -459,6 +462,7 @@ fail_error_normalization(Driver) ->
     % which exercises all normalize_error_term clauses (list, map, atom, tuple)
     ?assertMatch(
         #{
+            state := available,
             errors := [
                 #{
                     attempt := 1,
@@ -468,6 +472,125 @@ fail_error_normalization(Driver) ->
             ]
         } when is_integer(At),
         atomize_keys(gaffer:get(?Q, Id))
+    ).
+
+%--- Retries tests ------------------------------------------------------------
+
+retries_backoff(Driver) ->
+    Hook = gaffer_test_helpers:notify_hook(self(), [[gaffer, job, fail]]),
+    MaxAttempts = 5,
+    Backoff = [10, 20, 30],
+    [B1, B2, B3] = [
+        erlang:convert_time_unit(T, millisecond, native)
+     || T <- Backoff
+    ],
+    ok = gaffer:create_queue(
+        ?CONF(Driver, #{
+            poll_interval => 10,
+            max_attempts => MaxAttempts,
+            backoff => Backoff,
+            hooks => [Hook]
+        })
+    ),
+    #{id := Id, inserted_at := InsertedAt} = gaffer:insert(
+        ?Q, #{
+            ~"action" => ~"crash",
+            ~"test_pid" => gaffer_test_worker:encode_pid(self())
+        }
+    ),
+    % first attempt (not retry)
+    gaffer_test_helpers:await_hook(),
+    % retry 1
+    gaffer_test_helpers:await_hook(),
+    ?assertMatch(
+        #{
+            attempt := 2,
+            state := available,
+            errors := [#{at := At}, _]
+        } when At > (InsertedAt + B1),
+        gaffer:get(?Q, Id)
+    ),
+    % retry 2
+    gaffer_test_helpers:await_hook(),
+    ?assertMatch(
+        #{
+            attempt := 3,
+            state := available,
+            errors := [#{at := At}, _, _]
+        } when At > (InsertedAt + B1 + B2),
+        gaffer:get(?Q, Id)
+    ),
+    % retry 3
+    gaffer_test_helpers:await_hook(),
+    ?assertMatch(
+        #{
+            attempt := 4,
+            state := available,
+            errors := [#{at := At}, _, _, _]
+        } when At > (InsertedAt + B1 + B2 + B3),
+        gaffer:get(?Q, Id)
+    ),
+    % retry 5
+    gaffer_test_helpers:await_hook(),
+    ?assertMatch(
+        #{
+            attempt := 5,
+            state := discarded,
+            errors := [#{at := At}, _, _, _, _]
+        } when At > (InsertedAt + B1 + B2 + B3 + B3),
+        gaffer:get(?Q, Id)
+    ).
+
+retries_only_one_value(Driver) ->
+    Hook = gaffer_test_helpers:notify_hook(self(), [[gaffer, job, fail]]),
+    MaxAttempts = 4,
+    Backoff = 10,
+    BackoffNative = erlang:convert_time_unit(10, native, millisecond),
+    ok = gaffer:create_queue(
+        ?CONF(Driver, #{
+            poll_interval => 10,
+            max_attempts => MaxAttempts,
+            backoff => Backoff,
+            hooks => [Hook]
+        })
+    ),
+    #{id := Id, inserted_at := InsertedAt} = gaffer:insert(
+        ?Q, #{
+            ~"action" => ~"crash",
+            ~"test_pid" => gaffer_test_worker:encode_pid(self())
+        }
+    ),
+    % first attempt (not retry)
+    gaffer_test_helpers:await_hook(),
+    % retry 1
+    gaffer_test_helpers:await_hook(),
+    ?assertMatch(
+        #{
+            attempt := 2,
+            state := available,
+            errors := [#{at := At}, _]
+        } when At > (InsertedAt + BackoffNative),
+        gaffer:get(?Q, Id)
+    ),
+    % retry 2
+    gaffer_test_helpers:await_hook(),
+    ?assertMatch(
+        #{
+            attempt := 3,
+            state := available,
+            errors := [#{at := At}, _, _]
+        } when At > (InsertedAt + BackoffNative * 2),
+        gaffer:get(?Q, Id)
+    ),
+    % retry 3
+    gaffer_test_helpers:await_hook(),
+    ?assertMatch(
+        #{
+            attempt := 4,
+            state := discarded,
+            errors := [#{at := At}, _, _, _]
+        } when At > (InsertedAt + BackoffNative * 3),
+        gaffer:get(?Q, Id)
     ).
 
 %--- Schedule tests -----------------------------------------------------------


### PR DESCRIPTION
Retries with backoff

When a job fails and it has not yet reached max_retries then it is transitioned to `available` and scheduled into the future with the corresponding `backoff` value:
- If `backoff` contains exactly 1 item then that value is used 
- Otherwise for the N:th retry the value of N:th item is used
