### PR TITLE
feat: Remove failed state

### DIFF
--- a/src/gaffer.erl
+++ b/src/gaffer.erl
@@ -63,7 +63,6 @@
     available
     | executing
     | completed
-    | failed
     | cancelled
     | discarded.
 -doc #{group => "Queue Types"}.
@@ -174,7 +173,6 @@ An `erlang:system_time/0` integer or a `{Unit, Value}` pair.
         available := state_info(),
         executing := state_info(),
         completed := state_info(),
-        failed := state_info(),
         cancelled := state_info(),
         discarded := state_info()
     },

--- a/src/gaffer_driver_ets.erl
+++ b/src/gaffer_driver_ets.erl
@@ -178,7 +178,6 @@ info(Queue, #{queued := Queued, locked := Locked}) ->
         available => #{count => 0},
         executing => #{count => 0},
         completed => #{count => 0},
-        failed => #{count => 0},
         cancelled => #{count => 0},
         discarded => #{count => 0}
     },
@@ -213,7 +212,6 @@ accumulate_info(#{state := State} = Job, Acc) ->
 info_timestamp(available, #{inserted_at := T}) -> T;
 info_timestamp(executing, #{attempted_at := T}) -> T;
 info_timestamp(completed, #{completed_at := T}) -> T;
-info_timestamp(failed, #{attempted_at := T}) -> T;
 info_timestamp(cancelled, #{cancelled_at := T}) -> T;
 info_timestamp(discarded, #{discarded_at := T}) -> T;
 info_timestamp(_, _) -> undefined.

--- a/src/gaffer_driver_pgo.erl
+++ b/src/gaffer_driver_pgo.erl
@@ -132,7 +132,6 @@ info(Queue, #{pool := Pool}) ->
         available => #{count => 0},
         executing => #{count => 0},
         completed => #{count => 0},
-        failed => #{count => 0},
         cancelled => #{count => 0},
         discarded => #{count => 0}
     },

--- a/src/gaffer_postgres.erl
+++ b/src/gaffer_postgres.erl
@@ -61,7 +61,7 @@ migrations(#{}) ->
                                          REFERENCES gaffer_queues(name),
                     state            TEXT NOT NULL
                                          CHECK (state IN ('available', 'executing',
-                                                          'completed', 'failed', 'cancelled',
+                                                          'completed', 'cancelled',
                                                           'discarded')),
                     payload          JSONB NOT NULL,
                     attempt          INTEGER NOT NULL,
@@ -169,7 +169,6 @@ info(Queue) ->
         WHEN 'available' THEN inserted_at
         WHEN 'executing' THEN attempted_at
         WHEN 'completed' THEN completed_at
-        WHEN 'failed'    THEN attempted_at
         WHEN 'cancelled' THEN cancelled_at
         WHEN 'discarded' THEN discarded_at
     END

--- a/src/gaffer_queue.erl
+++ b/src/gaffer_queue.erl
@@ -256,10 +256,9 @@ fail_job(Queue, Id, Reason) ->
             attempt => Attempt, error => Reason, at => erlang:system_time()
         },
         Job2 = add_error(Job1, Error),
-        {ok, Job3} = transition(Job2, failed),
         case Attempt >= MaxAttempts of
-            true -> transition(Job3, discarded);
-            false -> {ok, Job3}
+            true -> transition(Job2, discarded);
+            false -> transition(Job2, available)
         end
     end),
     {ok, Job} = Result,
@@ -433,11 +432,9 @@ normalize_error_term(T) ->
 valid_transition(available, executing) -> true;
 valid_transition(available, cancelled) -> true;
 valid_transition(executing, completed) -> true;
-valid_transition(executing, failed) -> true;
 valid_transition(executing, cancelled) -> true;
 valid_transition(executing, available) -> true;
-valid_transition(failed, discarded) -> true;
-valid_transition(failed, available) -> true;
+valid_transition(executing, discarded) -> true;
 valid_transition(_, _) -> false.
 
 -spec set_timestamp(gaffer:job_state(), integer(), gaffer:job()) ->

--- a/test/gaffer_tests.erl
+++ b/test/gaffer_tests.erl
@@ -434,7 +434,7 @@ fail_retryable(Driver) ->
     gaffer_test_helpers:await_hook(),
     Failed = gaffer:get(?Q, Id),
     ?assertMatch(
-        #{state := failed, attempt := 1, errors := [#{attempt := 1}]}, Failed
+        #{state := available, attempt := 1, errors := [#{attempt := 1}]}, Failed
     ).
 
 fail_discarded(Driver) ->
@@ -611,7 +611,7 @@ poll_worker_crash_fails_job(Driver) ->
     #{id := Id} = gaffer:insert(?Q, #{~"action" => ~"crash"}),
     ok = gaffer_queue_runner:poll(?Q),
     gaffer_test_helpers:await_hook(),
-    ?assertMatch(#{state := failed}, gaffer:get(?Q, Id)).
+    ?assertMatch(#{state := available}, gaffer:get(?Q, Id)).
 
 poll_worker_complete_result(Driver) ->
     Hook = gaffer_test_helpers:notify_hook(self(), [[gaffer, job, complete]]),
@@ -813,7 +813,7 @@ forward_on_discard_retryable(Driver) ->
     }),
     ok = gaffer_queue_runner:poll(?Q),
     gaffer_test_helpers:await_hook(),
-    ?assertMatch(#{state := failed}, gaffer:get(?Q, Id)),
+    ?assertMatch(#{state := available}, gaffer:get(?Q, Id)),
     ?assertEqual([], gaffer:list(fwd_retry_dlq)).
 
 forward_on_discard_fresh(Driver) ->
@@ -848,7 +848,6 @@ info_empty_queue(Driver) ->
             available := #{count := 0},
             executing := #{count := 0},
             completed := #{count := 0},
-            failed := #{count := 0},
             cancelled := #{count := 0},
             discarded := #{count := 0}
         },


### PR DESCRIPTION
Returning `{fail, Reason}` from the job transitions to:
- state `available` when retries are possible
- state `discarded` when no more retries are possible